### PR TITLE
[feat] vercel 배포를 위한 index.html 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,50 @@
 <!DOCTYPE html>
-<html>
+<html lang="ko">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>README</title>
+
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css"
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+
+  <style>
+    body {
+      box-sizing: border-box;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 45px;
+    }
+
+    @media (max-width: 767px) {
+      body {
+        padding: 15px;
+      }
+    }
+  </style>
 </head>
 <body>
-  <pre id="content"></pre>
+  <article id="content" class="markdown-body">불러오는 중...</article>
 
-  <script>
-    fetch('./README.md')
-      .then(res => res.text())
-      .then(text => {
-        document.getElementById('content').textContent = text;
-      });
+  <script type="module">
+    import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
+
+    async function renderMarkdown() {
+      const res = await fetch("./README.md");
+      if (!res.ok) {
+        document.getElementById("content").textContent = "README.md를 불러오지 못했습니다.";
+        return;
+      }
+
+      const md = await res.text();
+      document.getElementById("content").innerHTML = marked.parse(md);
+    }
+
+    renderMarkdown();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>README</title>
+</head>
+<body>
+  <pre id="content"></pre>
+
+  <script>
+    fetch('./README.md')
+      .then(res => res.text())
+      .then(text => {
+        document.getElementById('content').textContent = text;
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 깃허브 페이지와 달리 Vercel은 앱을 기준으로 동작하기 때문에 html 파일 혹은 빌드 결과물(Vite, next.js 등)이 있어야 한다고 해요. 따라서 Vercel 배포를 위한 index.html을 추가했습니다. 
- 깃허브 페이지와 유사한 style을 적용하였습니다.

|    깃허브 페이지    |   Vercel 배포   |
| :-------------: | :-------------: |
| <img src = "https://github.com/user-attachments/assets/7ad1b04a-8cdb-464f-a609-1115147b5c75" width ="450"> | <img src = "https://github.com/user-attachments/assets/0425a52e-242e-49d3-9578-2bfc54b5b25f" width ="450"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 현재 assignment 브랜치를 Vercel로 배포했을 때의 화면을 스크린샷으로 첨부해두었습니다. 확인하시고 어프로브 남겨주시면 PR 머지 후 메인 브랜치로 배포하여 URL 제출하면 좋을 것 같습니당 🤩