### PR TITLE
[feat/#21]: add price calculation api

### DIFF
--- a/backend/src/main/java/com/vintic/backend/product/ProductController.java
+++ b/backend/src/main/java/com/vintic/backend/product/ProductController.java
@@ -1,0 +1,28 @@
+package com.vintic.backend.product;
+
+import com.vintic.backend.product.dto.CalculatePriceRequest;
+import com.vintic.backend.product.dto.CalculatePriceResponse;
+import com.vintic.backend.product.service.PriceCalculationService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+
+    private final PriceCalculationService priceCalculationService;
+
+    public ProductController(PriceCalculationService priceCalculationService) {
+        this.priceCalculationService = priceCalculationService;
+    }
+
+    
+    @PostMapping("/calculate-price")
+    public ResponseEntity<CalculatePriceResponse> calculatePrice(
+            @Valid @RequestBody CalculatePriceRequest request
+    ) {
+        CalculatePriceResponse response = priceCalculationService.calculate(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceRequest.java
+++ b/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceRequest.java
@@ -1,0 +1,26 @@
+package com.vintic.backend.product.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CalculatePriceRequest(
+
+        @NotBlank(message = "브랜드는 필수입니다.")
+        String brand,
+
+        @NotBlank(message = "모델명은 필수입니다.")
+        String model,
+
+        @NotBlank(message = "컬러웨이는 필수입니다.")
+        String colorway,
+
+        @NotNull(message = "한국 사이즈는 필수입니다.")
+        Integer sizeKr,
+
+        @NotBlank(message = "상품 상태 등급은 필수입니다.")
+        String conditionGrade,
+
+        @NotNull(message = "박스 포함 여부는 필수입니다.")
+        Boolean boxIncluded
+) {
+}

--- a/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceResponse.java
+++ b/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceResponse.java
@@ -1,0 +1,27 @@
+package com.vintic.backend.product.dto;
+
+import java.util.List;
+
+public record CalculatePriceResponse(
+        int recommendedPrice,
+        int baseMarketPrice,
+        int kreamAveragePrice,
+        int ebayAveragePrice,
+        String priceRange,
+        String reason,
+        List<MatchedMarketPrice> kreamMatches,
+        List<MatchedMarketPrice> ebayMatches
+) {
+    public record MatchedMarketPrice(
+            String source,
+            String brand,
+            String model,
+            String colorway,
+            Integer sizeKr,
+            String conditionGrade,
+            Boolean boxIncluded,
+            int price,
+            String url
+    ) {
+    }
+}

--- a/backend/src/main/java/com/vintic/backend/product/service/MarketPriceDataLoader.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/MarketPriceDataLoader.java
@@ -1,0 +1,216 @@
+package com.vintic.backend.product.service;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MarketPriceDataLoader {
+
+    private static final String KREAM_CSV_PATH = "data/kream_normalized.csv";
+    private static final String EBAY_CSV_PATH = "data/ebay_normalized.csv";
+
+    public List<MarketPriceRow> loadKreamRows() {
+        return loadRows(KREAM_CSV_PATH, "KREAM");
+    }
+
+    public List<MarketPriceRow> loadEbayRows() {
+        return loadRows(EBAY_CSV_PATH, "EBAY");
+    }
+
+    private List<MarketPriceRow> loadRows(String path, String source) {
+        try {
+            ClassPathResource resource = new ClassPathResource(path);
+
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8)
+            )) {
+                String headerLine = reader.readLine();
+
+                if (headerLine == null || headerLine.isBlank()) {
+                    return List.of();
+                }
+
+                List<String> headers = parseCsvLine(headerLine);
+                List<MarketPriceRow> rows = new ArrayList<>();
+
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.isBlank()) {
+                        continue;
+                    }
+
+                    List<String> values = parseCsvLine(line);
+
+                    MarketPriceRow row;
+                    if ("KREAM".equals(source)) {
+                        row = mapKreamRow(headers, values);
+                    } else {
+                        row = mapEbayRow(headers, values);
+                    }
+
+                    if (row != null) {
+                        rows.add(row);
+                    }
+                }
+
+                return rows;
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(source + " CSV 파일을 읽는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private MarketPriceRow mapKreamRow(List<String> headers, List<String> values) {
+        String brand = getValue(headers, values, "브랜드");
+        String model = getValue(headers, values, "모델명");
+        String colorway = getValue(headers, values, "컬러웨이");
+        String sizeKrText = getValue(headers, values, "한국 사이즈");
+        String priceText = getValue(headers, values, "KREAM 가격");
+        String conditionGrade = getValue(headers, values, "상태");
+        String url = getValue(headers, values, "상품 URL");
+
+        Integer sizeKr = parseInteger(sizeKrText);
+        Integer price = parseInteger(priceText);
+
+        if (isBlank(brand) || isBlank(model) || isBlank(colorway) || sizeKr == null || price == null) {
+            return null;
+        }
+
+        return new MarketPriceRow(
+                "KREAM",
+                brand,
+                model,
+                colorway,
+                sizeKr,
+                conditionGrade,
+                null,
+                price,
+                url
+        );
+    }
+
+    private MarketPriceRow mapEbayRow(List<String> headers, List<String> values) {
+        String brand = getValue(headers, values, "brand");
+        String model = getValue(headers, values, "model");
+        String colorway = getValue(headers, values, "colorway");
+        String sizeKrText = getValue(headers, values, "size_kr");
+        String priceText = getValue(headers, values, "ebay_price_krw");
+        String conditionGrade = getValue(headers, values, "condition_grade");
+        String boxIncludedText = getValue(headers, values, "box_included");
+        String url = getValue(headers, values, "item_url");
+
+        Integer sizeKr = parseInteger(sizeKrText);
+        Integer price = parseInteger(priceText);
+        Boolean boxIncluded = parseBoolean(boxIncludedText);
+
+        if (isBlank(brand) || isBlank(model) || isBlank(colorway) || sizeKr == null || price == null) {
+            return null;
+        }
+
+        return new MarketPriceRow(
+                "EBAY",
+                brand,
+                model,
+                colorway,
+                sizeKr,
+                conditionGrade,
+                boxIncluded,
+                price,
+                url
+        );
+    }
+
+    private String getValue(List<String> headers, List<String> values, String columnName) {
+        for (int i = 0; i < headers.size(); i++) {
+            if (headers.get(i).trim().equals(columnName)) {
+                if (i < values.size()) {
+                    return values.get(i).trim();
+                }
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private Integer parseInteger(String value) {
+        try {
+            if (isBlank(value)) {
+                return null;
+            }
+
+            String onlyNumber = value.replaceAll("[^0-9]", "");
+
+            if (onlyNumber.isBlank()) {
+                return null;
+            }
+
+            return Integer.parseInt(onlyNumber);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Boolean parseBoolean(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+
+        String normalized = value.trim().toLowerCase();
+
+        if ("true".equals(normalized)) {
+            return true;
+        }
+
+        if ("false".equals(normalized)) {
+            return false;
+        }
+
+        return null;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private List<String> parseCsvLine(String line) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char ch = line.charAt(i);
+
+            if (ch == '"') {
+                inQuotes = !inQuotes;
+            } else if (ch == ',' && !inQuotes) {
+                result.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(ch);
+            }
+        }
+
+        result.add(current.toString());
+        return result;
+    }
+
+    public record MarketPriceRow(
+            String source,
+            String brand,
+            String model,
+            String colorway,
+            Integer sizeKr,
+            String conditionGrade,
+            Boolean boxIncluded,
+            int price,
+            String url
+    ) {
+    }
+}

--- a/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
@@ -1,0 +1,211 @@
+package com.vintic.backend.product.service;
+
+import com.vintic.backend.product.dto.CalculatePriceRequest;
+import com.vintic.backend.product.dto.CalculatePriceResponse;
+import com.vintic.backend.product.service.MarketPriceDataLoader.MarketPriceRow;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class PriceCalculationService {
+
+    private final MarketPriceDataLoader marketPriceDataLoader;
+
+    public PriceCalculationService(MarketPriceDataLoader marketPriceDataLoader) {
+        this.marketPriceDataLoader = marketPriceDataLoader;
+    }
+
+    public CalculatePriceResponse calculate(CalculatePriceRequest request) {
+        List<MarketPriceRow> kreamRows = marketPriceDataLoader.loadKreamRows();
+        List<MarketPriceRow> ebayRows = marketPriceDataLoader.loadEbayRows();
+
+        List<MarketPriceRow> kreamMatches = findMatches(kreamRows, request);
+        List<MarketPriceRow> ebayMatches = findMatches(ebayRows, request);
+
+        int kreamAveragePrice = calculateAveragePrice(kreamMatches);
+        int ebayAveragePrice = calculateAveragePrice(ebayMatches);
+
+        if (kreamAveragePrice == 0 && ebayAveragePrice == 0) {
+            return new CalculatePriceResponse(
+                    0,
+                    0,
+                    0,
+                    0,
+                    "시세 정보 없음",
+                    "입력한 브랜드, 모델명, 컬러웨이, 사이즈와 일치하는 KREAM/eBay 시세 데이터를 찾지 못했습니다.",
+                    List.of(),
+                    List.of()
+            );
+        }
+
+        int baseMarketPrice = calculateBaseMarketPrice(kreamAveragePrice, ebayAveragePrice);
+
+        double conditionRate = getConditionRate(request.conditionGrade());
+        double boxRate = getBoxRate(request.boxIncluded());
+
+        int calculatedPrice = (int) Math.round(baseMarketPrice * conditionRate * boxRate);
+        int recommendedPrice = roundToNearestThousand(calculatedPrice);
+
+        String priceRange = makePriceRange(recommendedPrice);
+
+        String reason = makeReason(
+                kreamMatches.size(),
+                ebayMatches.size(),
+                kreamAveragePrice,
+                ebayAveragePrice,
+                baseMarketPrice,
+                request.conditionGrade(),
+                request.boxIncluded()
+        );
+
+        return new CalculatePriceResponse(
+                recommendedPrice,
+                baseMarketPrice,
+                kreamAveragePrice,
+                ebayAveragePrice,
+                priceRange,
+                reason,
+                toResponseMatches(kreamMatches),
+                toResponseMatches(ebayMatches)
+        );
+    }
+
+    private List<MarketPriceRow> findMatches(List<MarketPriceRow> rows, CalculatePriceRequest request) {
+        return rows.stream()
+                .filter(row -> equalsIgnoreCase(row.brand(), request.brand()))
+                .filter(row -> containsBothWays(row.model(), request.model()))
+                .filter(row -> containsBothWays(row.colorway(), request.colorway()))
+                .filter(row -> row.sizeKr().equals(request.sizeKr()))
+                .sorted(Comparator.comparingInt(MarketPriceRow::price))
+                .toList();
+    }
+
+    private int calculateAveragePrice(List<MarketPriceRow> rows) {
+        return (int) Math.round(
+                rows.stream()
+                        .mapToInt(MarketPriceRow::price)
+                        .average()
+                        .orElse(0)
+        );
+    }
+
+    private int calculateBaseMarketPrice(int kreamAveragePrice, int ebayAveragePrice) {
+        if (kreamAveragePrice > 0 && ebayAveragePrice > 0) {
+            return (int) Math.round(kreamAveragePrice * 0.7 + ebayAveragePrice * 0.3);
+        }
+
+        if (kreamAveragePrice > 0) {
+            return kreamAveragePrice;
+        }
+
+        return ebayAveragePrice;
+    }
+
+    private double getConditionRate(String conditionGrade) {
+        String grade = conditionGrade.trim().toUpperCase();
+
+        return switch (grade) {
+            case "DS" -> 1.00;
+            case "S" -> 0.97;
+            case "A" -> 0.92;
+            case "B" -> 0.82;
+            case "C" -> 0.70;
+            default -> 0.80;
+        };
+    }
+
+    private double getBoxRate(Boolean boxIncluded) {
+        if (boxIncluded == null) {
+            return 0.97;
+        }
+
+        return boxIncluded ? 1.00 : 0.95;
+    }
+
+    private int roundToNearestThousand(int price) {
+        return (int) Math.round(price / 1000.0) * 1000;
+    }
+
+    private String makePriceRange(int recommendedPrice) {
+        int min = roundToNearestThousand((int) (recommendedPrice * 0.95));
+        int max = roundToNearestThousand((int) (recommendedPrice * 1.05));
+
+        return String.format("%,d원 ~ %,d원", min, max);
+    }
+
+    private String makeReason(
+            int kreamCount,
+            int ebayCount,
+            int kreamAveragePrice,
+            int ebayAveragePrice,
+            int baseMarketPrice,
+            String conditionGrade,
+            Boolean boxIncluded
+    ) {
+        String boxText;
+
+        if (boxIncluded == null) {
+            boxText = "박스 포함 여부 알 수 없음";
+        } else if (boxIncluded) {
+            boxText = "박스 포함";
+        } else {
+            boxText = "박스 미포함";
+        }
+
+        return String.format(
+                "KREAM 유사 거래 %d건의 평균가 %,d원과 eBay 유사 거래 %d건의 평균가 %,d원을 바탕으로 기준 시세 %,d원을 계산했습니다. 이후 상품 상태 %s, %s 조건을 반영해 추천 가격을 산정했습니다.",
+                kreamCount,
+                kreamAveragePrice,
+                ebayCount,
+                ebayAveragePrice,
+                baseMarketPrice,
+                conditionGrade,
+                boxText
+        );
+    }
+
+    private List<CalculatePriceResponse.MatchedMarketPrice> toResponseMatches(List<MarketPriceRow> rows) {
+        return rows.stream()
+                .limit(5)
+                .map(row -> new CalculatePriceResponse.MatchedMarketPrice(
+                        row.source(),
+                        row.brand(),
+                        row.model(),
+                        row.colorway(),
+                        row.sizeKr(),
+                        row.conditionGrade(),
+                        row.boxIncluded(),
+                        row.price(),
+                        row.url()
+                ))
+                .toList();
+    }
+
+    private boolean equalsIgnoreCase(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+
+        return normalize(a).equals(normalize(b));
+    }
+
+    private boolean containsBothWays(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+
+        String normalizedA = normalize(a);
+        String normalizedB = normalize(b);
+
+        return normalizedA.contains(normalizedB) || normalizedB.contains(normalizedA);
+    }
+
+    private String normalize(String value) {
+        return value
+                .trim()
+                .toLowerCase()
+                .replaceAll("\\s+", "");
+    }
+}

--- a/backend/test.http
+++ b/backend/test.http
@@ -1,0 +1,11 @@
+POST http://localhost:8080/api/products/calculate-price
+Content-Type: application/json
+
+{
+  "brand": "Nike",
+  "model": "Dunk Low",
+  "colorway": "Panda",
+  "sizeKr": 275,
+  "conditionGrade": "A",
+  "boxIncluded": true
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #21

## 📄 작업 내용
- Spring Boot 기반 백엔드 프로젝트에 추천 가격 계산 API를 추가했습니다.
- `POST /api/products/calculate-price` API를 구현했습니다.
- `kream_normalized.csv`, `ebay_normalized.csv` 데이터를 읽어 유사 상품 시세를 조회하도록 구현했습니다.
- KREAM/eBay 평균 시세를 기반으로 기준 시세를 계산하도록 구현했습니다.
- 상품 상태 등급과 박스 포함 여부를 반영해 최종 추천 가격을 산정하도록 구현했습니다.
- API 동작 확인용 `test.http` 파일을 추가했습니다.

## 💻 주요 코드 설명

### `ProductController.java`
- `/api/products/calculate-price` 요청을 받는 컨트롤러입니다.
- 요청 데이터를 `CalculatePriceRequest`로 받고, 계산 결과를 `CalculatePriceResponse`로 반환합니다.

### `CalculatePriceRequest.java`
- 프론트에서 전달하는 가격 계산 요청 DTO입니다.
- 브랜드, 모델명, 컬러웨이, 한국 사이즈, 상태 등급, 박스 포함 여부를 받습니다.

### `CalculatePriceResponse.java`
- 추천 가격 계산 결과 응답 DTO입니다.
- 추천 가격, 기준 시세, KREAM 평균가, eBay 평균가, 가격 범위, 산정 이유, 매칭된 시세 데이터를 반환합니다.

### `MarketPriceDataLoader.java`
- `src/main/resources/data` 경로의 CSV 파일을 읽어 가격 데이터로 변환합니다.
- KREAM CSV와 eBay CSV의 서로 다른 컬럼 구조를 각각 매핑합니다.

### `PriceCalculationService.java`
- 브랜드, 모델명, 컬러웨이, 사이즈를 기준으로 유사 상품을 검색합니다.
- KREAM/eBay 평균 시세를 계산합니다.
- 상태 등급과 박스 포함 여부를 반영해 추천 가격을 산정합니다.

<details>
<summary>PriceCalculationService.java</summary>

```java
추천 가격 계산 흐름

1. KREAM/eBay CSV 데이터 로드
2. 요청값과 일치하는 유사 상품 검색
3. KREAM 평균가, eBay 평균가 계산
4. 기준 시세 계산
   - KREAM/eBay 모두 존재: KREAM 70%, eBay 30% 가중 평균
   - KREAM만 존재: KREAM 평균가
   - eBay만 존재: eBay 평균가
5. 상태 등급 보정률 반영
6. 박스 포함 여부 보정률 반영
7. 1,000원 단위 반올림 후 추천 가격 반환

📚 참고자료
backend/src/main/resources/data/kream_normalized.csv
backend/src/main/resources/data/ebay_normalized.csv
👀 기타 더 이야기해볼 점
현재 MVP 기준으로 브랜드, 모델명, 컬러웨이, 한국 사이즈를 기준으로 매칭합니다.
eBay와 KREAM의 상품명 표기 방식이 다를 경우 매칭률이 낮을 수 있어, 추후 유사도 기반 매칭 로직 개선이 필요합니다.
PowerShell에서 한글 응답이 깨져 보일 수 있으나, API 계산 결과는 정상적으로 반환되는 것을 확인했습니다.