### PR TITLE
[feat/#43] parse analyze response dto 구현

### DIFF
--- a/backend/src/main/java/com/vintic/backend/ai/service/OpenAiService.java
+++ b/backend/src/main/java/com/vintic/backend/ai/service/OpenAiService.java
@@ -1,6 +1,9 @@
 package com.vintic.backend.ai.service;
 
-import com.vintic.backend.ai.prompt.ProductAnalysisPrompt; // 작성하신 프롬프트 클래스 import
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vintic.backend.ai.prompt.ProductAnalysisPrompt;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -9,10 +12,13 @@ import org.springframework.web.client.RestTemplate;
 import java.util.*;
 
 @Service
+@RequiredArgsConstructor
 public class OpenAiService {
+
     @Value("${openai.api.key}")
     private String apiKey;
 
+    private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate = new RestTemplate();
 
     public String analyzeProductImage(String imageUrl) {
@@ -23,16 +29,11 @@ public class OpenAiService {
         headers.setBearerAuth(apiKey);
 
         Map<String, Object> body = new HashMap<>();
-        body.put("model", "gpt-4o"); // 최신 멀티모달 모델
+        body.put("model", "gpt-4o");
 
-        // 시스템 메시지: 프롬프트 세팅
         Map<String, Object> systemMessage = new HashMap<>();
         systemMessage.put("role", "system");
         systemMessage.put("content", ProductAnalysisPrompt.SYSTEM_PROMPT);
-
-        // 유저 메시지: S3에 올라간 이미지 URL 세팅
-        Map<String, Object> userMessage = new HashMap<>();
-        userMessage.put("role", "user");
 
         Map<String, Object> imageUrlMap = new HashMap<>();
         imageUrlMap.put("url", imageUrl);
@@ -41,12 +42,12 @@ public class OpenAiService {
         imageContent.put("type", "image_url");
         imageContent.put("image_url", imageUrlMap);
 
+        Map<String, Object> userMessage = new HashMap<>();
+        userMessage.put("role", "user");
         userMessage.put("content", Collections.singletonList(imageContent));
 
-        //95 메시지 리스트에 시스템 역할과 유저 역할을 순서대로 삽입
         body.put("messages", Arrays.asList(systemMessage, userMessage));
 
-        // OpenAI가 무조건 JSON 형태로만 대답하도록 강제하는 옵션
         Map<String, Object> responseFormat = new HashMap<>();
         responseFormat.put("type", "json_object");
         body.put("response_format", responseFormat);
@@ -55,11 +56,28 @@ public class OpenAiService {
 
         HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        // API 호출
         ResponseEntity<String> response = restTemplate.exchange(
-                url, HttpMethod.POST, requestEntity, String.class
+                url,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
         );
 
-        return response.getBody();
+        return extractContent(response.getBody());
+    }
+
+    private String extractContent(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            return root.path("choices")
+                    .get(0)
+                    .path("message")
+                    .path("content")
+                    .asText();
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException("OpenAI 응답에서 분석 결과를 추출할 수 없습니다.", e);
+        }
     }
 }

--- a/backend/src/main/java/com/vintic/backend/analyze/controller/AnalyzeController.java
+++ b/backend/src/main/java/com/vintic/backend/analyze/controller/AnalyzeController.java
@@ -1,5 +1,6 @@
 package com.vintic.backend.analyze.controller;
 
+import com.vintic.backend.analyze.dto.AnalyzeResponse;
 import com.vintic.backend.analyze.service.ProductAnalyzeService;
 import com.vintic.backend.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -8,37 +9,29 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-
-
-//S3UploaderService에 프론트가 보낸 이미지를 전달하는 컨트롤러
+// 프론트가 보낸 이미지를 받아 S3 업로드 및 AI 분석을 수행하는 컨트롤러
 @RestController
 @RequestMapping("/api/products")
 @RequiredArgsConstructor
 public class AnalyzeController {
 
     private final ProductAnalyzeService productAnalyzeService;
-    
 
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<?>> analyzeImage(@RequestPart("image") MultipartFile image) {
-        // 빈 파일이 오면 쫓아냄
         if (image == null || image.isEmpty()) {
-            return ResponseEntity.badRequest().body(ApiResponse.fail(400, "이미지 파일이 없습니다."));
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.fail(40002, "이미지 파일이 없습니다."));
         }
 
         try {
-            //서비스 호출(S3 업로드+OpenAI 분석)
-            String aiAnalysisResult = productAnalyzeService.processImageAndAnalyze(image);
-
-            // 최종 AI 분석 결과를 기존 공통 ApiResponse 성공 포맷에 담아 반환
-            return ResponseEntity.ok(ApiResponse.success(aiAnalysisResult));
+            AnalyzeResponse response = productAnalyzeService.processImageAndAnalyze(image);
+            return ResponseEntity.ok(ApiResponse.success(response));
 
         } catch (Exception e) {
-            // 업로드 또는 ai 분석 중 에러가 터지면 500 에러 반환
-            e.printStackTrace(); //개발용. 운영 환경에선 log.error()로 대체
-            return ResponseEntity.internalServerError().body(ApiResponse.fail(500,"이미지 업로드에 실패했습니다."));
+            e.printStackTrace();
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.fail(50003, "이미지 분석에 실패했습니다."));
         }
     }
-
-
 }

--- a/backend/src/main/java/com/vintic/backend/analyze/service/ProductAnalyzeService.java
+++ b/backend/src/main/java/com/vintic/backend/analyze/service/ProductAnalyzeService.java
@@ -1,28 +1,44 @@
 package com.vintic.backend.analyze.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vintic.backend.ai.service.OpenAiService;
-import com.vintic.backend.analyze.service.S3UploaderService;
+import com.vintic.backend.analyze.dto.AnalyzeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @Service
 @RequiredArgsConstructor
 public class ProductAnalyzeService {
-    // 우리가 만든 두 개의 부품을 가져옵니다.
+
     private final S3UploaderService s3Service;
     private final OpenAiService openAiService;
+    private final ObjectMapper objectMapper;
 
-    // 파이프라인 메서드
-    public String processImageAndAnalyze(MultipartFile imageFile) {
+    public AnalyzeResponse processImageAndAnalyze(MultipartFile imageFile) {
+        try {
+            String imageUrl = s3Service.uploadImage(imageFile);
+            String aiAnalysisResult = openAiService.analyzeProductImage(imageUrl);
 
-        // 프론트에서 받은 이미지를 S3에 업로드하고 URL을 받아옴
-        String imageUrl = s3Service.uploadImage(imageFile);
+            AnalyzeResponse response = objectMapper.readValue(aiAnalysisResult, AnalyzeResponse.class);
 
-        // 받아온 S3 URL을 OpenAI에게 던져서 분석 결과를 받아옴
-        String aiAnalysisResult = openAiService.analyzeProductImage(imageUrl);
+            return new AnalyzeResponse(
+                    imageUrl,
+                    response.brand(),
+                    response.modelName(),
+                    response.color(),
+                    response.size(),
+                    response.conditionDescription(),
+                    response.conditionGrade()
+            );
 
-        // DB 저장 없이, 분석 결과(OpenAI가 준 JSON 문자열)만 그대로 리턴
-        return aiAnalysisResult;
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("AI 분석 응답을 파싱할 수 없습니다.", e);
+        } catch (IOException e) {
+            throw new IllegalStateException("이미지 업로드 중 오류가 발생했습니다.", e);
+        }
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    include: secret
 
 cloud:
   aws:
@@ -13,9 +15,8 @@ cloud:
 openai:
   api:
     key: ${OPENAI_API_KEY}
+
 logging:
   level:
     root: INFO
     com.vintic.backend: INFO
-
-


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #43

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- OpenAI API 응답에서 실제 분석 결과 JSON 문자열을 추출하도록 수정했습니다.
- 추출한 JSON 문자열을 `ObjectMapper`로 `AnalyzeResponse` DTO 객체로 변환하도록 구현했습니다.
- `ProductAnalyzeService`의 반환 타입을 `String`에서 `AnalyzeResponse`로 변경했습니다.
- `AnalyzeController`의 응답이 문자열이 아닌 구조화된 DTO 객체를 반환하도록 수정했습니다.
- 이미지 업로드, OpenAI 호출, JSON 파싱 과정에서 발생하는 예외 처리를 추가했습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->

### OpenAI 응답 content 추출

- OpenAI Chat Completions API 응답 전체 JSON에서 `choices[0].message.content` 값을 추출하도록 수정했습니다.
- 기존에는 OpenAI 전체 응답 문자열을 그대로 반환했기 때문에 `AnalyzeResponse`로 바로 파싱할 수 없었습니다.
- 이제 `content` 안에 들어있는 실제 분석 JSON 문자열만 반환합니다.

<details>
<summary>OpenAiService.java</summary>

```java
private String extractContent(String responseBody) {
    try {
        JsonNode root = objectMapper.readTree(responseBody);

        return root.path("choices")
                .get(0)
                .path("message")
                .path("content")
                .asText();

    } catch (Exception e) {
        throw new IllegalArgumentException("OpenAI 응답에서 분석 결과를 추출할 수 없습니다.", e);
    }
}
```
</details>

### AI 분석 응답 DTO 파싱

- `ProductAnalyzeService`에서 OpenAI가 반환한 분석 JSON 문자열을 `AnalyzeResponse` DTO로 변환합니다.
- S3 업로드 후 획득한 이미지 URL은 DTO의 `imgUrl` 값으로 직접 넣어 반환합니다.

<details>
<summary>ProductAnalyzeService.java</summary>

```java
AnalyzeResponse response = objectMapper.readValue(aiAnalysisResult, AnalyzeResponse.class);

return new AnalyzeResponse(
        imageUrl,
        response.brand(),
        response.modelName(),
        response.color(),
        response.size(),
        response.conditionDescription(),
        response.conditionGrade()
);
```
</details>

### analyze API 응답 구조 변경

- 기존에는 `data`에 OpenAI 응답 문자열이 그대로 들어갔습니다.
- 이제는 `data`에 `AnalyzeResponse` 객체가 들어가도록 변경했습니다.

<details>
<summary>AnalyzeController.java</summary>

```java
AnalyzeResponse response = productAnalyzeService.processImageAndAnalyze(image);
return ResponseEntity.ok(ApiResponse.success(response));
```
</details>

### 기대 응답 형태

```json
{
  "success": true,
  "data": {
    "imgUrl": "https://vintic-mvp-bucket-123.s3.ap-northeast-2.amazonaws.com/sample.png",
    "brand": "Nike",
    "modelName": "Dunk Low",
    "color": "Panda",
    "size": 275,
    "conditionDescription": "전체적으로 양호한 상태",
    "conditionGrade": "A"
  },
  "error": null
}
```

## ✅ 테스트
- Spring Boot 서버 정상 실행 확인
- `POST /api/products/calculate-price` 정상 응답 확인
- `POST /api/products/analyze` 요청이 서버까지 도달하는 것 확인
- S3 업로드 후 OpenAI API 호출 단계까지 진입하는 것 확인
- 현재 OpenAI API 응답에서 `429 insufficient_quota` 발생 확인
  - 원인: OpenAI API 키의 billing/credit 문제로 추정
  - 결제/크레딧 설정 후 실제 AI 분석 성공 응답 검증 필요

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- OpenAI API 결제/크레딧 설정 전까지는 실제 AI 분석 성공 응답 검증이 어렵습니다.
- 결제/크레딧 설정 후 `POST /api/products/analyze`를 다시 테스트해 DTO 파싱 결과를 최종 확인해야 합니다.