### PR TITLE
[feat/#45] 가격 계산 공식 및 산정 이유 보완

### DIFF
--- a/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
@@ -11,6 +11,12 @@ import java.util.List;
 @Service
 public class PriceCalculationService {
 
+    private static final double KREAM_WEIGHT = 0.7;
+    private static final double EBAY_WEIGHT = 0.3;
+    private static final double PRICE_RANGE_RATE = 0.05;
+    private static final double DEFAULT_CONDITION_RATE = 0.80;
+    private static final String UNKNOWN_CONDITION_GRADE = "UNKNOWN";
+
     private final MarketPriceDataLoader marketPriceDataLoader;
 
     public PriceCalculationService(MarketPriceDataLoader marketPriceDataLoader) {
@@ -34,7 +40,7 @@ public class PriceCalculationService {
                     0,
                     0,
                     "시세 정보 없음",
-                    "입력한 브랜드, 모델명, 컬러웨이, 사이즈와 일치하는 KREAM/eBay 시세 데이터를 찾지 못했습니다.",
+                    "입력한 브랜드, 모델명, 컬러웨이, 사이즈와 일치하는 KREAM/eBay 시세 데이터를 찾지 못했습니다. 추천 가격 산정을 위해서는 유사 거래 데이터가 추가로 필요합니다.",
                     List.of(),
                     List.of()
             );
@@ -42,7 +48,8 @@ public class PriceCalculationService {
 
         int baseMarketPrice = calculateBaseMarketPrice(kreamAveragePrice, ebayAveragePrice);
 
-        double conditionRate = getConditionRate(request.conditionGrade());
+        String normalizedConditionGrade = normalizeConditionGrade(request.conditionGrade());
+        double conditionRate = getConditionRate(normalizedConditionGrade);
         double boxRate = getBoxRate(request.boxIncluded());
 
         int calculatedPrice = (int) Math.round(baseMarketPrice * conditionRate * boxRate);
@@ -56,8 +63,12 @@ public class PriceCalculationService {
                 kreamAveragePrice,
                 ebayAveragePrice,
                 baseMarketPrice,
-                request.conditionGrade(),
-                request.boxIncluded()
+                recommendedPrice,
+                normalizedConditionGrade,
+                conditionRate,
+                request.boxIncluded(),
+                boxRate,
+                priceRange
         );
 
         return new CalculatePriceResponse(
@@ -93,7 +104,7 @@ public class PriceCalculationService {
 
     private int calculateBaseMarketPrice(int kreamAveragePrice, int ebayAveragePrice) {
         if (kreamAveragePrice > 0 && ebayAveragePrice > 0) {
-            return (int) Math.round(kreamAveragePrice * 0.7 + ebayAveragePrice * 0.3);
+            return (int) Math.round(kreamAveragePrice * KREAM_WEIGHT + ebayAveragePrice * EBAY_WEIGHT);
         }
 
         if (kreamAveragePrice > 0) {
@@ -103,16 +114,22 @@ public class PriceCalculationService {
         return ebayAveragePrice;
     }
 
-    private double getConditionRate(String conditionGrade) {
-        String grade = conditionGrade.trim().toUpperCase();
+    private String normalizeConditionGrade(String conditionGrade) {
+        if (conditionGrade == null || conditionGrade.isBlank()) {
+            return UNKNOWN_CONDITION_GRADE;
+        }
 
-        return switch (grade) {
+        return conditionGrade.trim().toUpperCase();
+    }
+
+    private double getConditionRate(String normalizedConditionGrade) {
+        return switch (normalizedConditionGrade) {
             case "DS" -> 1.00;
             case "S" -> 0.97;
             case "A" -> 0.92;
             case "B" -> 0.82;
             case "C" -> 0.70;
-            default -> 0.80;
+            default -> DEFAULT_CONDITION_RATE;
         };
     }
 
@@ -129,8 +146,8 @@ public class PriceCalculationService {
     }
 
     private String makePriceRange(int recommendedPrice) {
-        int min = roundToNearestThousand((int) (recommendedPrice * 0.95));
-        int max = roundToNearestThousand((int) (recommendedPrice * 1.05));
+        int min = roundToNearestThousand((int) Math.round(recommendedPrice * (1 - PRICE_RANGE_RATE)));
+        int max = roundToNearestThousand((int) Math.round(recommendedPrice * (1 + PRICE_RANGE_RATE)));
 
         return String.format("%,d원 ~ %,d원", min, max);
     }
@@ -141,28 +158,168 @@ public class PriceCalculationService {
             int kreamAveragePrice,
             int ebayAveragePrice,
             int baseMarketPrice,
-            String conditionGrade,
-            Boolean boxIncluded
+            int recommendedPrice,
+            String normalizedConditionGrade,
+            double conditionRate,
+            Boolean boxIncluded,
+            double boxRate,
+            String priceRange
     ) {
-        String boxText;
+        String marketPriceText = makeMarketPriceText(
+                kreamCount,
+                ebayCount,
+                kreamAveragePrice,
+                ebayAveragePrice,
+                baseMarketPrice
+        );
 
-        if (boxIncluded == null) {
-            boxText = "박스 포함 여부 알 수 없음";
-        } else if (boxIncluded) {
-            boxText = "박스 포함";
-        } else {
-            boxText = "박스 미포함";
+        String conditionText = makeConditionText(normalizedConditionGrade, conditionRate);
+        String boxText = makeBoxText(boxIncluded, boxRate);
+        String comparisonText = makeComparisonText(kreamAveragePrice, ebayAveragePrice, recommendedPrice);
+
+        return String.format(
+                "%s %s %s 이를 바탕으로 최종 추천가는 %,d원으로 산정했으며, 판매 권장 범위는 %s입니다. %s",
+                marketPriceText,
+                conditionText,
+                boxText,
+                recommendedPrice,
+                priceRange,
+                comparisonText
+        );
+    }
+
+    private String makeMarketPriceText(
+            int kreamCount,
+            int ebayCount,
+            int kreamAveragePrice,
+            int ebayAveragePrice,
+            int baseMarketPrice
+    ) {
+        if (kreamAveragePrice > 0 && ebayAveragePrice > 0) {
+            return String.format(
+                    "KREAM 유사 거래 %d건의 평균가 %,d원과 eBay 유사 거래 %d건의 평균가 %,d원을 각각 %.0f%%, %.0f%% 비율로 반영해 기준 시세 %,d원을 계산했습니다.",
+                    kreamCount,
+                    kreamAveragePrice,
+                    ebayCount,
+                    ebayAveragePrice,
+                    KREAM_WEIGHT * 100,
+                    EBAY_WEIGHT * 100,
+                    baseMarketPrice
+            );
+        }
+
+        if (kreamAveragePrice > 0) {
+            return String.format(
+                    "KREAM 유사 거래 %d건의 평균가 %,d원을 기준 시세로 사용했습니다.",
+                    kreamCount,
+                    kreamAveragePrice
+            );
         }
 
         return String.format(
-                "KREAM 유사 거래 %d건의 평균가 %,d원과 eBay 유사 거래 %d건의 평균가 %,d원을 바탕으로 기준 시세 %,d원을 계산했습니다. 이후 상품 상태 %s, %s 조건을 반영해 추천 가격을 산정했습니다.",
-                kreamCount,
-                kreamAveragePrice,
+                "KREAM 유사 거래는 찾지 못했지만, eBay 유사 거래 %d건의 평균가 %,d원을 기준 시세로 사용했습니다.",
                 ebayCount,
-                ebayAveragePrice,
-                baseMarketPrice,
-                conditionGrade,
-                boxText
+                ebayAveragePrice
+        );
+    }
+
+    private String makeConditionText(String normalizedConditionGrade, double conditionRate) {
+        String description = getConditionDescription(normalizedConditionGrade);
+
+        if (UNKNOWN_CONDITION_GRADE.equals(normalizedConditionGrade)) {
+            return String.format(
+                    "상품 상태 등급이 명확하지 않아 기본 반영률 %.0f%%를 적용했습니다.",
+                    conditionRate * 100
+            );
+        }
+
+        if ("기타 상태".equals(description)) {
+            return String.format(
+                    "상품 상태 등급 %s는 사전에 정의되지 않은 값이므로 기본 반영률 %.0f%%를 적용했습니다.",
+                    normalizedConditionGrade,
+                    conditionRate * 100
+            );
+        }
+
+        return String.format(
+                "상품 상태는 %s(%s)로 판단하여 %.0f%% 반영률을 적용했습니다.",
+                normalizedConditionGrade,
+                description,
+                conditionRate * 100
+        );
+    }
+
+    private String getConditionDescription(String conditionGrade) {
+        return switch (conditionGrade) {
+            case "DS" -> "새상품";
+            case "S" -> "거의 새상품";
+            case "A" -> "양호한 중고";
+            case "B" -> "사용감 있음";
+            case "C" -> "하자 있음";
+            default -> "기타 상태";
+        };
+    }
+
+    private String makeBoxText(Boolean boxIncluded, double boxRate) {
+        if (boxIncluded == null) {
+            return String.format(
+                    "구성품 여부는 확인되지 않아 %.0f%% 반영률을 적용했습니다.",
+                    boxRate * 100
+            );
+        }
+
+        if (boxIncluded) {
+            return String.format(
+                    "박스가 포함되어 있어 %.0f%% 반영률을 적용했습니다.",
+                    boxRate * 100
+            );
+        }
+
+        return String.format(
+                "박스가 포함되지 않아 %.0f%% 반영률을 적용했습니다.",
+                boxRate * 100
+        );
+    }
+
+    private String makeComparisonText(int kreamAveragePrice, int ebayAveragePrice, int recommendedPrice) {
+        if (kreamAveragePrice > 0) {
+            return makePriceComparisonText("KREAM 평균가", kreamAveragePrice, recommendedPrice);
+        }
+
+        if (ebayAveragePrice > 0) {
+            return makePriceComparisonText("eBay 평균가", ebayAveragePrice, recommendedPrice);
+        }
+
+        return "";
+    }
+
+    private String makePriceComparisonText(String sourceName, int averagePrice, int recommendedPrice) {
+        if (averagePrice == 0) {
+            return "";
+        }
+
+        double differenceRate = ((double) recommendedPrice - averagePrice) / averagePrice * 100;
+        int roundedDifferenceRate = (int) Math.round(Math.abs(differenceRate));
+
+        if (roundedDifferenceRate == 0) {
+            return String.format(
+                    "추천가는 %s와 거의 동일한 수준입니다.",
+                    sourceName
+            );
+        }
+
+        if (differenceRate > 0) {
+            return String.format(
+                    "추천가는 %s 대비 약 %d%% 높은 수준입니다.",
+                    sourceName,
+                    roundedDifferenceRate
+            );
+        }
+
+        return String.format(
+                "추천가는 %s 대비 약 %d%% 낮은 수준입니다.",
+                sourceName,
+                roundedDifferenceRate
         );
     }
 

--- a/backend/test.http
+++ b/backend/test.http
@@ -1,3 +1,4 @@
+### 가격 계산 - A등급 + 박스 포함
 POST http://localhost:8080/api/products/calculate-price
 Content-Type: application/json
 
@@ -6,6 +7,45 @@ Content-Type: application/json
   "model": "Dunk Low",
   "colorway": "Panda",
   "sizeKr": 275,
+  "conditionGrade": "A",
+  "boxIncluded": true
+}
+
+### 가격 계산 - A등급 + 박스 미포함
+POST http://localhost:8080/api/products/calculate-price
+Content-Type: application/json
+
+{
+  "brand": "Nike",
+  "model": "Dunk Low",
+  "colorway": "Panda",
+  "sizeKr": 275,
+  "conditionGrade": "A",
+  "boxIncluded": false
+}
+
+### 가격 계산 - C등급 + 박스 포함
+POST http://localhost:8080/api/products/calculate-price
+Content-Type: application/json
+
+{
+  "brand": "Nike",
+  "model": "Dunk Low",
+  "colorway": "Panda",
+  "sizeKr": 275,
+  "conditionGrade": "C",
+  "boxIncluded": true
+}
+
+### 가격 계산 - 시세 없음 케이스
+POST http://localhost:8080/api/products/calculate-price
+Content-Type: application/json
+
+{
+  "brand": "Unknown",
+  "model": "Unknown Model",
+  "colorway": "Unknown Color",
+  "sizeKr": 999,
   "conditionGrade": "A",
   "boxIncluded": true
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #45

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `POST /api/products/calculate-price` API의 가격 계산 공식과 산정 이유 문구를 보완했습니다.
- `conditionGrade`에 따른 상태 반영률을 명확히 적용했습니다.
  - `DS`: 100%
  - `S`: 97%
  - `A`: 92%
  - `B`: 82%
  - `C`: 70%
  - 그 외 정의되지 않은 값: 기본 80%
- `boxIncluded` 여부에 따른 구성품 반영률을 적용했습니다.
  - 박스 포함: 100%
  - 박스 미포함: 95%
  - 구성품 여부 확인 불가: 97%
- KREAM/eBay 평균 시세 기반 기준가 계산 로직을 상수화했습니다.
  - KREAM: 70%
  - eBay: 30%
- 계산된 추천 가격을 1,000원 단위로 반올림하고, ±5% 판매 권장 범위를 반환하도록 유지했습니다.
- 가격 산정 이유 `reason` 문구에 기준 시세, 상태 반영률, 구성품 반영률, 추천가 비교 내용을 포함하도록 개선했습니다.
- KREAM/eBay 시세 데이터가 없을 경우 기본 응답을 반환하는 Fallback을 유지했습니다.
- 정의되지 않은 상태 등급이 들어와도 서버가 터지지 않고 기본 반영률을 적용하도록 Fallback을 보완했습니다.
- `test.http`에 가격 계산 테스트 케이스를 추가했습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->

### 가격 계산 공식 보완

- KREAM/eBay 평균 시세를 기반으로 기준 시세를 계산합니다.
- KREAM과 eBay 데이터가 모두 있으면 KREAM 70%, eBay 30% 비율로 반영합니다.
- 이후 상품 상태 반영률과 구성품 반영률을 곱해 추천 가격을 산정합니다.

<details>
<summary>PriceCalculationService.java</summary>

```java
private static final double KREAM_WEIGHT = 0.7;
private static final double EBAY_WEIGHT = 0.3;
private static final double PRICE_RANGE_RATE = 0.05;
private static final double DEFAULT_CONDITION_RATE = 0.80;
private static final String UNKNOWN_CONDITION_GRADE = "UNKNOWN";
```

```java
int calculatedPrice = (int) Math.round(baseMarketPrice * conditionRate * boxRate);
int recommendedPrice = roundToNearestThousand(calculatedPrice);
```
</details>

### 상태 등급 Fallback 보완

- `conditionGrade`가 비어 있거나 정의되지 않은 값이어도 서버가 터지지 않도록 처리했습니다.
- 정의되지 않은 상태 등급은 기본 반영률 80%를 적용합니다.

<details>
<summary>PriceCalculationService.java</summary>

```java
private String normalizeConditionGrade(String conditionGrade) {
    if (conditionGrade == null || conditionGrade.isBlank()) {
        return UNKNOWN_CONDITION_GRADE;
    }

    return conditionGrade.trim().toUpperCase();
}

private double getConditionRate(String normalizedConditionGrade) {
    return switch (normalizedConditionGrade) {
        case "DS" -> 1.00;
        case "S" -> 0.97;
        case "A" -> 0.92;
        case "B" -> 0.82;
        case "C" -> 0.70;
        default -> DEFAULT_CONDITION_RATE;
    };
}
```
</details>

### 가격 산정 이유 문구 개선

- 기존보다 더 자세한 산정 이유를 반환하도록 개선했습니다.
- 기준 시세, 상태 반영률, 박스 포함 여부, 최종 추천가, 판매 권장 범위, 평균가 대비 차이를 포함합니다.

<details>
<summary>응답 reason 예시</summary>

```text
KREAM 유사 거래 1건의 평균가 104,000원을 기준 시세로 사용했습니다.
상품 상태는 A(양호한 중고)로 판단하여 92% 반영률을 적용했습니다.
박스가 포함되어 있어 100% 반영률을 적용했습니다.
이를 바탕으로 최종 추천가는 96,000원으로 산정했으며, 판매 권장 범위는 91,000원 ~ 101,000원입니다.
추천가는 KREAM 평균가 대비 약 8% 낮은 수준입니다.
```
</details>

## ✅ 테스트

- `POST /api/products/calculate-price` 정상 응답 확인
- A등급 + 박스 포함 케이스 확인
  - 기준 시세: `104,000원`
  - 계산식: `104,000 × 0.92 × 1.00 = 95,680`
  - 추천 가격: `96,000원`
- A등급 + 박스 미포함 케이스 확인
  - 계산식: `104,000 × 0.92 × 0.95 = 90,896`
  - 추천 가격: `91,000원`
- 정의되지 않은 상태 등급 Fallback 확인
  - 입력값: `UNKNOWN`
  - 계산식: `104,000 × 0.80 × 1.00 = 83,200`
  - 추천 가격: `83,000원`
- 시세 없음 Fallback 확인
  - `recommendedPrice`: `0`
  - `baseMarketPrice`: `0`
  - `priceRange`: `시세 정보 없음`

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- PowerShell 출력에서는 한글이 깨져 보일 수 있지만, API 응답 자체는 정상적으로 반환되는 것을 확인했습니다.
- 이번 PR은 Day6 가격 계산 공식 보완, Day7 산정 이유 문구 개선, Day9 가격 계산 Fallback 보완을 함께 포함합니다.