### PR TITLE
[refactor/#51] 상태 등급별 가격 보정률 조정

### DIFF
--- a/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
@@ -14,7 +14,7 @@ public class PriceCalculationService {
     private static final double KREAM_WEIGHT = 0.7;
     private static final double EBAY_WEIGHT = 0.3;
     private static final double PRICE_RANGE_RATE = 0.05;
-    private static final double DEFAULT_CONDITION_RATE = 0.80;
+    private static final double DEFAULT_CONDITION_RATE = 0.60;
     private static final String UNKNOWN_CONDITION_GRADE = "UNKNOWN";
 
     private final MarketPriceDataLoader marketPriceDataLoader;
@@ -124,11 +124,11 @@ public class PriceCalculationService {
 
     private double getConditionRate(String normalizedConditionGrade) {
         return switch (normalizedConditionGrade) {
-            case "DS" -> 1.00;
-            case "S" -> 0.97;
-            case "A" -> 0.92;
-            case "B" -> 0.82;
-            case "C" -> 0.70;
+            case "DS" -> 0.80;
+            case "S" -> 0.70;
+            case "A" -> 0.60;
+            case "B" -> 0.40;
+            case "C" -> 0.20;
             default -> DEFAULT_CONDITION_RATE;
         };
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #51

## 📄 작업 내용
- `POST /api/products/calculate-price` API의 상태 등급별 가격 보정률을 조정했습니다.
- 기존에는 DS/A/B/C 등급 간 가격 차이가 작아, AI 이미지 분석 결과가 추천 가격에 충분히 반영되지 않았습니다.
- 상태가 좋지 않은 상품일수록 추천 가격이 더 크게 낮아지도록 감가율을 강화했습니다.
- UNKNOWN 또는 정의되지 않은 상태 등급은 기본 반영률 60%를 적용하도록 수정했습니다.
- 가격 계산 공식의 전체 구조는 유지하고, 상태 등급별 보정률만 수정했습니다.

## 변경된 상태 등급별 반영률

| 상태 등급 | 기존 반영률 | 변경 반영률 |
|---|---:|---:|
| DS | 100% | 80% |
| S | 97% | 70% |
| A | 92% | 60% |
| B | 82% | 40% |
| C | 70% | 20% |
| UNKNOWN | 80% | 60% |

## 💻 주요 코드 설명

### 상태 등급별 보정률 조정

```java
private static final double DEFAULT_CONDITION_RATE = 0.60;