### PR TITLE
[feat/#50] 에러 로직 추가

### DIFF
--- a/backend/src/main/java/com/vintic/backend/ai/service/OpenAiService.java
+++ b/backend/src/main/java/com/vintic/backend/ai/service/OpenAiService.java
@@ -3,6 +3,7 @@ package com.vintic.backend.ai.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vintic.backend.ai.prompt.ProductAnalysisPrompt;
+import com.vintic.backend.common.exception.AiApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -15,6 +16,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class OpenAiService {
 
+
     @Value("${openai.api.key}")
     private String apiKey;
 
@@ -22,48 +24,54 @@ public class OpenAiService {
     private final RestTemplate restTemplate = new RestTemplate();
 
     public String analyzeProductImage(String imageUrl) {
-        String url = "https://api.openai.com/v1/chat/completions";
+        try {
+            String url = "https://api.openai.com/v1/chat/completions";
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(apiKey);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
 
-        Map<String, Object> body = new HashMap<>();
-        body.put("model", "gpt-4o");
+            Map<String, Object> body = new HashMap<>();
+            body.put("model", "gpt-4o");
 
-        Map<String, Object> systemMessage = new HashMap<>();
-        systemMessage.put("role", "system");
-        systemMessage.put("content", ProductAnalysisPrompt.SYSTEM_PROMPT);
+            Map<String, Object> systemMessage = new HashMap<>();
+            systemMessage.put("role", "system");
+            systemMessage.put("content", ProductAnalysisPrompt.SYSTEM_PROMPT);
 
-        Map<String, Object> imageUrlMap = new HashMap<>();
-        imageUrlMap.put("url", imageUrl);
+            Map<String, Object> imageUrlMap = new HashMap<>();
+            imageUrlMap.put("url", imageUrl);
 
-        Map<String, Object> imageContent = new HashMap<>();
-        imageContent.put("type", "image_url");
-        imageContent.put("image_url", imageUrlMap);
+            Map<String, Object> imageContent = new HashMap<>();
+            imageContent.put("type", "image_url");
+            imageContent.put("image_url", imageUrlMap);
 
-        Map<String, Object> userMessage = new HashMap<>();
-        userMessage.put("role", "user");
-        userMessage.put("content", Collections.singletonList(imageContent));
+            Map<String, Object> userMessage = new HashMap<>();
+            userMessage.put("role", "user");
+            userMessage.put("content", Collections.singletonList(imageContent));
 
-        body.put("messages", Arrays.asList(systemMessage, userMessage));
+            body.put("messages", Arrays.asList(systemMessage, userMessage));
 
-        Map<String, Object> responseFormat = new HashMap<>();
-        responseFormat.put("type", "json_object");
-        body.put("response_format", responseFormat);
+            Map<String, Object> responseFormat = new HashMap<>();
+            responseFormat.put("type", "json_object");
+            body.put("response_format", responseFormat);
 
-        body.put("max_tokens", 1000);
+            body.put("max_tokens", 1000);
 
-        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+            HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        ResponseEntity<String> response = restTemplate.exchange(
-                url,
-                HttpMethod.POST,
-                requestEntity,
-                String.class
-        );
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    requestEntity,
+                    String.class
+            );
 
-        return extractContent(response.getBody());
+            return extractContent(response.getBody());
+
+        } catch (Exception e) {
+            // OpenAI 타임아웃/오류 발생 시 전용 에러 던지기
+            throw new AiApiException("AI 분석 API 호출 중 오류가 발생했습니다.");
+        }
     }
 
     private String extractContent(String responseBody) {

--- a/backend/src/main/java/com/vintic/backend/analyze/controller/AnalyzeController.java
+++ b/backend/src/main/java/com/vintic/backend/analyze/controller/AnalyzeController.java
@@ -18,20 +18,9 @@ public class AnalyzeController {
     private final ProductAnalyzeService productAnalyzeService;
 
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<?>> analyzeImage(@RequestPart("image") MultipartFile image) {
-        if (image == null || image.isEmpty()) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.fail(40002, "이미지 파일이 없습니다."));
-        }
-
-        try {
-            AnalyzeResponse response = productAnalyzeService.processImageAndAnalyze(image);
-            return ResponseEntity.ok(ApiResponse.success(response));
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.internalServerError()
-                    .body(ApiResponse.fail(50003, "이미지 분석에 실패했습니다."));
-        }
+    public ResponseEntity<ApiResponse<AnalyzeResponse>> analyzeImage(@RequestPart("image") MultipartFile image) {
+        // 에러나면 서비스가 알아서 던지고 Advice가 알아서 처리함
+        AnalyzeResponse aiAnalysisResult = productAnalyzeService.processImageAndAnalyze(image);
+        return ResponseEntity.ok(ApiResponse.success(aiAnalysisResult));
     }
 }

--- a/backend/src/main/java/com/vintic/backend/analyze/service/ProductAnalyzeService.java
+++ b/backend/src/main/java/com/vintic/backend/analyze/service/ProductAnalyzeService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vintic.backend.ai.service.OpenAiService;
 import com.vintic.backend.analyze.dto.AnalyzeResponse;
+import com.vintic.backend.common.exception.AiApiException;
+import com.vintic.backend.common.exception.InvalidImageException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,9 +21,14 @@ public class ProductAnalyzeService {
     private final ObjectMapper objectMapper;
 
     public AnalyzeResponse processImageAndAnalyze(MultipartFile imageFile) {
+
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new InvalidImageException("이미지 파일이 존재하지 않습니다.");
+        }
+
         try {
-            String imageUrl = s3Service.uploadImage(imageFile);
-            String aiAnalysisResult = openAiService.analyzeProductImage(imageUrl);
+            String imageUrl = s3Service.uploadImage(imageFile);//실패시 s3업로드 에러 날아감
+            String aiAnalysisResult = openAiService.analyzeProductImage(imageUrl);//ai 분석 실패시 에러 날아감
 
             AnalyzeResponse response = objectMapper.readValue(aiAnalysisResult, AnalyzeResponse.class);
 
@@ -36,9 +43,7 @@ public class ProductAnalyzeService {
             );
 
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("AI 분석 응답을 파싱할 수 없습니다.", e);
-        } catch (IOException e) {
-            throw new IllegalStateException("이미지 업로드 중 오류가 발생했습니다.", e);
+            throw new AiApiException("AI 분석 응답을 처리하는 중 오류가 발생했습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/vintic/backend/analyze/service/S3UploaderService.java
+++ b/backend/src/main/java/com/vintic/backend/analyze/service/S3UploaderService.java
@@ -1,5 +1,6 @@
 package com.vintic.backend.analyze.service;
 
+import com.vintic.backend.common.exception.S3UploadException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -21,27 +22,36 @@ public class S3UploaderService {
     private String bucket;
 
 
-    public String uploadImage(MultipartFile image) throws IOException {
-        // 파일명 추출 및 변환
-        String originalFilename = image.getOriginalFilename();
-        String uniqueFilename = UUID.randomUUID() + "_" + originalFilename; // 난수 붙이기 (예: 1234_신발.jpg)
+    public String uploadImage(MultipartFile image) {
 
-        // S3 업로드 요청서 작성
-        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(bucket) // 어느 버킷에?
-                .key(uniqueFilename) // 무슨 이름으로?
-                .contentType(image.getContentType()) // 파일 종류는 뭐야? (이미지)
-                .build();
+        try {
+            // 파일명 추출 및 변환
+            String originalFilename = image.getOriginalFilename();
+            String uniqueFilename = UUID.randomUUID() + "_" + originalFilename; // 난수 붙이기 (예: 1234_신발.jpg)
 
-        // 파일 전송 (진짜 업로드 명령)
-        s3Client.putObject(putObjectRequest,
-                RequestBody.fromInputStream(image.getInputStream(), image.getSize()));
+            // S3 업로드 요청서 작성
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket) // 어느 버킷에?
+                    .key(uniqueFilename) // 무슨 이름으로?
+                    .contentType(image.getContentType()) // 파일 종류? (이미지)
+                    .build();
 
-        // URL 조립
-        // S3 기본 주소 + 버킷 이름 + 리전(서울) + 파일이름을 합침
-        String imageUrl = "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + uniqueFilename;
+            // 파일 전송 (진짜 업로드 명령)
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromInputStream(image.getInputStream(), image.getSize()));
 
-        return imageUrl; // 완성된 주소를 컨트롤러로
+            // URL 조립
+            // S3 기본 주소 + 버킷 이름 + 지역(서울) + 파일이름을 합침
+            String imageUrl = "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + uniqueFilename;
+
+            return imageUrl; // 완성된 주소를 컨트롤러로
+        } catch (Exception e) {
+            // S3 에러 발생 시 전용 에러로 바꿔서 던지기
+            throw new S3UploadException("S3 이미지 업로드 중 문제가 발생했습니다.");
+        }
+
+
+
     }
 
 

--- a/backend/src/main/java/com/vintic/backend/common/exception/AiApiException.java
+++ b/backend/src/main/java/com/vintic/backend/common/exception/AiApiException.java
@@ -1,0 +1,8 @@
+package com.vintic.backend.common.exception;
+
+public class AiApiException extends RuntimeException {
+    public AiApiException(String message) {
+
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/vintic/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/vintic/backend/common/exception/GlobalExceptionHandler.java
@@ -26,12 +26,33 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(40001, message));
     }
 
+    // 빈 이미지 에러 처리 (400 Bad Request)
+    @ExceptionHandler(InvalidImageException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidImageException(InvalidImageException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(40002, e.getMessage()));
+    }
+
+    // S3 업로드 에러 처리 (500 Internal Server Error)
+    @ExceptionHandler(S3UploadException.class)
+    public ResponseEntity<ApiResponse<Void>> handleS3UploadException(S3UploadException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(50002, e.getMessage()));
+    }
+
+    // OpenAI 통신 에러 처리 (500 Internal Server Error)
+    @ExceptionHandler(AiApiException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAiApiException(AiApiException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(50003, e.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception exception) {
-        // 1. 에러 내용을 콘솔에 강제로 출력 (가장 중요!)
+        // 1. 에러 내용을 콘솔에 강제로 출력
         exception.printStackTrace();
 
-        // 2. 개발자를 위한 상세 메시지 (실제 서비스에서는 보안상 숨겨야 하지만, 지금은 개발 중이니 출력합니다)
+        // 2. 개발자를 위한 상세 메시지 (실제 서비스에서는 보안상 숨겨야 하지만, 지금은 개발 중이니 출력)
         String detailMessage = exception.getMessage();
 
         return ResponseEntity

--- a/backend/src/main/java/com/vintic/backend/common/exception/InvalidImageException.java
+++ b/backend/src/main/java/com/vintic/backend/common/exception/InvalidImageException.java
@@ -1,0 +1,7 @@
+package com.vintic.backend.common.exception;
+
+public class InvalidImageException extends RuntimeException {
+    public InvalidImageException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/vintic/backend/common/exception/S3UploadException.java
+++ b/backend/src/main/java/com/vintic/backend/common/exception/S3UploadException.java
@@ -1,0 +1,7 @@
+package com.vintic.backend.common.exception;
+
+public class S3UploadException extends RuntimeException {
+    public S3UploadException(String message){
+        super(message);
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #50 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 도메인별 커스텀 예외 클래스 추가: 에러 추적과 명확한 응답을 위해 3가지 커스텀 예외(InvalidImageException, S3UploadException, AiApiException) 신규 생성
- 비즈니스 로직(Service) 방어막 구축: 각 서비스(ProductAnalyzeService, S3UploaderService) 로직 수행 중 문제 발생 시 커스텀 예외를 throw 하도록 로직 수정
- Controller 리팩토링: AnalyzeController에 있던 지저분한 try-catch와 검증 로직을 걷어내어 핵심 성공 로직만 남도록 깔끔하게 분리

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### @RestControllerAdvice를 활용한 에러 공통 포맷 처리 및 컨트롤러 리팩토링

- Service 계층에서 특정 상황(빈 이미지, S3 서버 통신 실패, AI API 파싱 실패 등)에 커스텀 에러를 던지면, GlobalExceptionHandler가 이를 낚아채어 프론트엔드와 약속한 ApiResponse.fail() 규격으로 예쁘게 포장해 반환합니다.

<details>
<summary>GlobalExceptionHandler.java</summary>

```java
@RestControllerAdvice
public class GlobalExceptionHandler {

    // 빈 이미지 에러 처리 (400 Bad Request)
    @ExceptionHandler(InvalidImageException.class)
    public ResponseEntity<ApiResponse<Void>> handleInvalidImageException(InvalidImageException e) {
        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                .body(ApiResponse.fail(40002, e.getMessage()));
    }

    // OpenAI 통신 에러 처리 (500 Internal Server Error)
    @ExceptionHandler(AiApiException.class)
    public ResponseEntity<ApiResponse<Void>> handleAiApiException(AiApiException e) {
        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                .body(ApiResponse.fail(50003, e.getMessage()));
    }
    
    // ... S3UploadException 및 기타 Exception 처리 로직 포함
}
```
</details>


