### PR TITLE
[refactor/#65] 추천 가격 범위 숫자 필드 추가

### DIFF
--- a/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceResponse.java
+++ b/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceResponse.java
@@ -7,6 +7,8 @@ public record CalculatePriceResponse(
         int baseMarketPrice,
         int kreamAveragePrice,
         int ebayAveragePrice,
+        int minRecommendedPrice,
+        int maxRecommendedPrice,
         String priceRange,
         String reason,
         List<MatchedMarketPrice> kreamMatches,

--- a/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
@@ -39,8 +39,10 @@ public class PriceCalculationService {
                     0,
                     0,
                     0,
+                    0,
+                    0,
                     "시세 정보 없음",
-                    "입력한 브랜드, 모델명, 컬러웨이, 사이즈와 일치하는 KREAM/eBay 시세 데이터를 찾지 못했습니다. 추천 가격 산정을 위해서는 유사 거래 데이터가 추가로 필요합니다.",
+                    "입력한 브랜드, 모델명, 색상, 사이즈와 일치하는 KREAM/eBay 시세 데이터를 찾지 못했습니다. 추천 가격 산정을 위해서는 유사 거래 데이터가 추가로 필요합니다.",
                     List.of(),
                     List.of()
             );
@@ -55,7 +57,9 @@ public class PriceCalculationService {
         int calculatedPrice = (int) Math.round(baseMarketPrice * conditionRate * componentRate);
         int recommendedPrice = roundToNearestThousand(calculatedPrice);
 
-        String priceRange = makePriceRange(recommendedPrice);
+        int minRecommendedPrice = calculateMinRecommendedPrice(recommendedPrice);
+        int maxRecommendedPrice = calculateMaxRecommendedPrice(recommendedPrice);
+        String priceRange = makePriceRange(minRecommendedPrice, maxRecommendedPrice);
 
         String reason = makeReason(
                 kreamMatches.size(),
@@ -76,6 +80,8 @@ public class PriceCalculationService {
                 baseMarketPrice,
                 kreamAveragePrice,
                 ebayAveragePrice,
+                minRecommendedPrice,
+                maxRecommendedPrice,
                 priceRange,
                 reason,
                 toResponseMatches(kreamMatches),
@@ -150,11 +156,16 @@ public class PriceCalculationService {
         return (int) Math.round(price / 1000.0) * 1000;
     }
 
-    private String makePriceRange(int recommendedPrice) {
-        int min = roundToNearestThousand((int) Math.round(recommendedPrice * (1 - PRICE_RANGE_RATE)));
-        int max = roundToNearestThousand((int) Math.round(recommendedPrice * (1 + PRICE_RANGE_RATE)));
+    private int calculateMinRecommendedPrice(int recommendedPrice) {
+        return roundToNearestThousand((int) Math.round(recommendedPrice * (1 - PRICE_RANGE_RATE)));
+    }
 
-        return String.format("%,d원 ~ %,d원", min, max);
+    private int calculateMaxRecommendedPrice(int recommendedPrice) {
+        return roundToNearestThousand((int) Math.round(recommendedPrice * (1 + PRICE_RANGE_RATE)));
+    }
+
+    private String makePriceRange(int minRecommendedPrice, int maxRecommendedPrice) {
+        return String.format("%,d원 ~ %,d원", minRecommendedPrice, maxRecommendedPrice);
     }
 
     private String makeReason(


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #65

## 📄 작업 내용
- 추천 가격 계산 API 응답에 `minRecommendedPrice`, `maxRecommendedPrice` 숫자 필드를 추가했습니다.
- 기존 `priceRange` 문자열 필드는 하위 호환성을 위해 유지했습니다.
- 프론트에서 `"23,000원 ~ 25,000원"` 문자열을 직접 파싱하지 않고, 최소/최대 추천가를 숫자값으로 바로 사용할 수 있도록 수정했습니다.
- 시세 데이터가 없는 경우 `minRecommendedPrice`, `maxRecommendedPrice`를 `0`으로 반환하도록 처리했습니다.

## 💻 주요 코드 설명

### 추천 가격 범위 숫자 필드 추가

- `CalculatePriceResponse`에 `minRecommendedPrice`, `maxRecommendedPrice` 필드를 추가했습니다.
- 기존 `priceRange`는 그대로 유지했습니다.

