### PR TITLE
[feat/#69] 등록 상품 목록 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/vintic/backend/product/ProductController.java
+++ b/backend/src/main/java/com/vintic/backend/product/ProductController.java
@@ -4,12 +4,15 @@ import com.vintic.backend.common.dto.ApiResponse;
 import com.vintic.backend.product.dto.CalculatePriceRequest;
 import com.vintic.backend.product.dto.CalculatePriceResponse;
 import com.vintic.backend.product.dto.CreateProductRequest;
+import com.vintic.backend.product.dto.ProductListResponse;
 import com.vintic.backend.product.dto.ProductResponse;
 import com.vintic.backend.product.service.PriceCalculationService;
 import com.vintic.backend.product.service.ProductRegistrationService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
@@ -39,6 +42,12 @@ public class ProductController {
             @Valid @RequestBody CreateProductRequest request
     ) {
         ProductResponse response = productRegistrationService.createProduct(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProductListResponse>>> getProducts() {
+        List<ProductListResponse> response = productRegistrationService.getProducts();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/vintic/backend/product/dto/ProductListResponse.java
+++ b/backend/src/main/java/com/vintic/backend/product/dto/ProductListResponse.java
@@ -1,0 +1,29 @@
+package com.vintic.backend.product.dto;
+
+import com.vintic.backend.product.domain.Product;
+
+import java.time.LocalDateTime;
+
+public record ProductListResponse(
+        Long id,
+        String thumbnailImageUrl,
+        String brand,
+        String modelName,
+        Integer sellingPrice,
+        LocalDateTime createdAt
+) {
+    public static ProductListResponse from(Product product) {
+        String thumbnailImageUrl = product.getImageUrls().isEmpty()
+                ? null
+                : product.getImageUrls().get(0);
+
+        return new ProductListResponse(
+                product.getId(),
+                thumbnailImageUrl,
+                product.getBrand(),
+                product.getModel(),
+                product.getFinalPrice(),
+                product.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/vintic/backend/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/vintic/backend/product/repository/ProductRepository.java
@@ -3,5 +3,9 @@ package com.vintic.backend.product.repository;
 import com.vintic.backend.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    List<Product> findAllByOrderByCreatedAtDesc();
 }

--- a/backend/src/main/java/com/vintic/backend/product/service/ProductRegistrationService.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/ProductRegistrationService.java
@@ -2,10 +2,13 @@ package com.vintic.backend.product.service;
 
 import com.vintic.backend.product.domain.Product;
 import com.vintic.backend.product.dto.CreateProductRequest;
+import com.vintic.backend.product.dto.ProductListResponse;
 import com.vintic.backend.product.dto.ProductResponse;
 import com.vintic.backend.product.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class ProductRegistrationService {
@@ -36,5 +39,13 @@ public class ProductRegistrationService {
 
         Product savedProduct = productRepository.save(product);
         return ProductResponse.from(savedProduct);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductListResponse> getProducts() {
+        return productRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(ProductListResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #69

## 📄 작업 내용
- 홈 화면에서 등록된 상품 목록을 조회할 수 있도록 `GET /api/products` API를 추가했습니다.
- 상품 목록 응답용 DTO인 `ProductListResponse`를 추가했습니다.
- 홈 화면 상품 카드에 필요한 최소 정보만 반환하도록 구성했습니다.
- 대표 이미지는 `imageUrls` 배열의 첫 번째 이미지 URL을 `thumbnailImageUrl`로 반환하도록 처리했습니다.
- 상품 목록은 최신 등록순으로 조회되도록 Repository에 `findAllByOrderByCreatedAtDesc()` 메서드를 추가했습니다.

## 💻 주요 코드 설명

### 상품 목록 응답 DTO 추가

- 홈 화면 카드에서 필요한 상품 ID, 대표 이미지, 브랜드명, 모델명, 판매가, 등록일을 반환합니다.
- `thumbnailImageUrl`은 등록된 이미지 URL 목록 중 첫 번째 값을 사용합니다.

<details>
<summary>ProductListResponse.java</summary>

```java
public record ProductListResponse(
        Long id,
        String thumbnailImageUrl,
        String brand,
        String modelName,
        Integer sellingPrice,
        LocalDateTime createdAt
) {
    public static ProductListResponse from(Product product) {
        String thumbnailImageUrl = product.getImageUrls().isEmpty()
                ? null
                : product.getImageUrls().get(0);

        return new ProductListResponse(
                product.getId(),
                thumbnailImageUrl,
                product.getBrand(),
                product.getModel(),
                product.getFinalPrice(),
                product.getCreatedAt()
        );
    }
}