### PR TITLE
[refactor/#74] 추천 가격 응답 필드명 통일

### DIFF
--- a/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceResponse.java
+++ b/backend/src/main/java/com/vintic/backend/product/dto/CalculatePriceResponse.java
@@ -17,11 +17,11 @@ public record CalculatePriceResponse(
     public record MatchedMarketPrice(
             String source,
             String brand,
-            String model,
-            String colorway,
-            Integer sizeKr,
+            String modelName,
+            String color,
+            Integer size,
             String conditionGrade,
-            Boolean boxIncluded,
+            String componentStatus,
             int price,
             String url
     ) {

--- a/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
+++ b/backend/src/main/java/com/vintic/backend/product/service/PriceCalculationService.java
@@ -342,21 +342,29 @@ public class PriceCalculationService {
     }
 
     private List<CalculatePriceResponse.MatchedMarketPrice> toResponseMatches(List<MarketPriceRow> rows) {
-        return rows.stream()
-                .limit(5)
-                .map(row -> new CalculatePriceResponse.MatchedMarketPrice(
-                        row.source(),
-                        row.brand(),
-                        row.model(),
-                        row.colorway(),
-                        row.sizeKr(),
-                        row.conditionGrade(),
-                        row.boxIncluded(),
-                        row.price(),
-                        row.url()
-                ))
-                .toList();
+    return rows.stream()
+            .limit(5)
+            .map(row -> new CalculatePriceResponse.MatchedMarketPrice(
+                    row.source(),
+                    row.brand(),
+                    row.model(),
+                    row.colorway(),
+                    row.sizeKr(),
+                    row.conditionGrade(),
+                    toComponentStatus(row.boxIncluded()),
+                    row.price(),
+                    row.url()
+            ))
+            .toList();
     }
+
+private String toComponentStatus(Boolean boxIncluded) {
+    if (boxIncluded == null) {
+        return "NONE";
+    }
+
+    return boxIncluded ? "FULL" : "NONE";
+}
 
     private boolean equalsIgnoreCase(String a, String b) {
         if (a == null || b == null) {


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #74

## 📄 작업 내용
- 추천 가격 계산 API 응답의 `kreamMatches`, `ebayMatches` 내부 필드명을 프론트 DTO 기준으로 통일했습니다.
- 기존 `model`, `colorway`, `sizeKr`, `boxIncluded` 필드를 `modelName`, `color`, `size`, `componentStatus`로 변경했습니다.
- 기존 시장 데이터의 `boxIncluded` 값을 `componentStatus`로 변환하도록 수정했습니다.
  - `true` → `FULL`
  - `false` 또는 `null` → `NONE`
- `POST /api/products/calculate-price` 응답에서 변경된 필드명이 정상 반환되는지 확인했습니다.

## 💻 주요 코드 설명

### 유사 거래 응답 DTO 필드명 변경

- `CalculatePriceResponse` 내부의 `MatchedMarketPrice` 필드명을 프론트 DTO 구조에 맞게 수정했습니다.
- `kreamMatches`, `ebayMatches` 모두 동일한 응답 구조를 사용합니다.

<details>
<summary>CalculatePriceResponse.java</summary>

```java
public record MatchedMarketPrice(
        String source,
        String brand,
        String modelName,
        String color,
        Integer size,
        String conditionGrade,
        String componentStatus,
        int price,
        String url
) {
}